### PR TITLE
Update README.md

### DIFF
--- a/react-oidc-client/README.md
+++ b/react-oidc-client/README.md
@@ -25,7 +25,7 @@ The Client will need to be configured with this:
 {
 	"name": "Verify React OIDC Sample App",
 	"redirectUris": [
-		"https://localhost:3000/signin-callback.html`"
+		"http://localhost:3000/signin-callback.html"
 	],
 	"responseTypes": [
 		"code"


### PR DESCRIPTION
I assume the use of HTTPS for a localhost endpoint is a typo, and also the trailing single backtick in the same URL.