### PR TITLE
fix(issue-direct-credential-express): use @stablelib/base64 library

### DIFF
--- a/issue-direct-credential-express/package.json
+++ b/issue-direct-credential-express/package.json
@@ -21,6 +21,7 @@
     "trailingComma": "all"
   },
   "dependencies": {
+    "@stablelib/base64": "1.0.1",
     "body-parser": "1.19.0",
     "dotenv": "^10.0.0",
     "ejs": "3.1.6",

--- a/issue-direct-credential-express/src/service.ts
+++ b/issue-direct-credential-express/src/service.ts
@@ -1,6 +1,7 @@
 import assert from "assert";
 import qrcode from "qrcode";
 import { v4 as uuid } from "uuid";
+import * as base64 from "@stablelib/base64";
 
 import { RequestContext } from "./types";
 
@@ -11,7 +12,7 @@ const shortenUrls = new Map<string, ShortenItem>();
 /**
  * The Direct Credential Offer JWM message much be Base64 URL encoded
  */
-const base64UrlEncode = (str: string) => encodeURIComponent(Buffer.from(str).toString("base64"));
+const base64UrlEncode = (str: string) => base64.encodeURLSafe(Buffer.from(str));
 
 /**
  * Cache the created templates to reduce the resource consumption

--- a/issue-direct-credential-express/yarn.lock
+++ b/issue-direct-credential-express/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
   integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
 
+"@stablelib/base64@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@stablelib/base64/-/base64-1.0.1.tgz#bdfc1c6d3a62d7a3b7bbc65b6cce1bb4561641be"
+  integrity sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==
+
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-4.0.5.tgz#bfbd50211e9dfa51ba07da58a14cdfd333205152"


### PR DESCRIPTION
We must use the same Base64 encoding library as the Mobile Wallet, otherwise, the MW won't be able to decode the DIDComm message in some cases.