### PR TITLE
Update packages.json to fix build

### DIFF
--- a/oidc-client-react/package.json
+++ b/oidc-client-react/package.json
@@ -19,7 +19,7 @@
     "toastr": "2.1.4"
   },
   "scripts": {
-    "start": "set PORT=4200 && react-scripts start",
+    "start": "cross-env PORT=4200 && react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
@@ -36,8 +36,9 @@
     "@types/react-json-tree": "0.6.11",
     "@types/react-test-renderer": "16.8.2",
     "@types/toastr": "2.1.37",
+    "cross-env": "^7.0.3",
     "react-app-env": "^1.2.3",
-    "typescript": "3.4.5"
+    "typescript": "4.4.4"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This update helped me fix two issues:
- The `yarn start` command was failing because the `PORT=4200` environment variable was set using an incompatible command (on MacOS and Windows). Introduced `cross-env` as a dev dependency to support multiple OSes.
- The `yarn start` command was failing because of an internal Typescript bug: `__spreadArrays is not defined`. Updating Typescript fixed this bug for me.