### PR TITLE
remove optional expiresTime request field

### DIFF
--- a/verify-callback-express/verify-callback-express.js
+++ b/verify-callback-express/verify-callback-express.js
@@ -64,7 +64,6 @@ const ngrok = require('ngrok');
             "challenge": "GW8FGpP6jhFrl37yQZIM6w",
             "did": process.env.VERIFIERDID,
             "templateId": process.env.TEMPLATEID,
-            "expiresTime": 1638836401000,
             "callbackUrl": `${ngrokUrl}/callback`
         },
         responseType: 'json'


### PR DESCRIPTION
Was getting a bad request when running through the `verify-callback-express` sample, and it turns out the hard coded expiresTime field in the sample was causing a 400 bad request. It's optional according to the [API spec](https://learn.mattr.global/api-reference/v1.0.1#operation/createPresRequest), removing it entirely solves it 👍