### PR TITLE
Fixing root URL for well-known DID configuration

### DIFF
--- a/postman/MATTR Tenant env.postman_environment.json
+++ b/postman/MATTR Tenant env.postman_environment.json
@@ -53,9 +53,9 @@
 			"enabled": true
 		},
 		{
-			"key": " ",
-			"value": "",
-			"enabled": false
+			"key": "tenant_subdomain",
+			"value": "YOUR_MATTR_TENANT_SUBDOMAIN",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/postman/Platform Core API.postman_collection.json
+++ b/postman/Platform Core API.postman_collection.json
@@ -131,7 +131,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/.well-known/did-configuration",
+							"raw": "https://{{tenant_subdomain}}.vii.mattr.global/.well-known/did-configuration",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -158,9 +158,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/.well-known/did-configuration",
+									"raw": "https://{{tenant_subdomain}}.vii.mattr.global/.well-known/did-configuration",
 									"host": [
-										"{{baseUrl}}"
+										"https://{{tenant_subdomain}}.vii.mattr.global/"
 									],
 									"path": [
 										".well-known",

--- a/postman/Platform Core API.postman_collection.json
+++ b/postman/Platform Core API.postman_collection.json
@@ -158,9 +158,9 @@
 									}
 								],
 								"url": {
-									"raw": "https://{{tenant_subdomain}}.vii.mattr.global/.well-known/did-configuration",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/.well-known/did-configuration",
 									"host": [
-										"https://{{tenant_subdomain}}.vii.mattr.global/"
+										"{{tenant_subdomain}}.vii.mattr.global/"
 									],
 									"path": [
 										".well-known",


### PR DESCRIPTION
Problem found:
`GET .well-known/did-configuration` shouldn't use `{{ baseUrl }}` which has `/core/` as a postfix. Instead, we can make a separate environment variable to only store MATTR tenants and use it in situations like this. See below for comparisons

Before:
![image](https://user-images.githubusercontent.com/111719473/208776714-642caea1-4df6-4c97-a401-74ef04fe780a.png)

After:
![image](https://user-images.githubusercontent.com/111719473/208776752-f76add32-3a8d-472c-b54f-1faaf0f4c22b.png)

