### PR TITLE
refactor: using generic root tenant for endpoints

### DIFF
--- a/postman/MATTR Tenant env.postman_environment.json
+++ b/postman/MATTR Tenant env.postman_environment.json
@@ -3,11 +3,6 @@
 	"name": "MATTR Tenant env",
 	"values": [
 		{
-			"key": "baseUrl",
-			"value": "https://tenant.vii.mattr.global/core",
-			"enabled": true
-		},
-		{
 			"key": "extUrl",
 			"value": "https://tenant.vii.mattr.global/ext",
 			"enabled": true
@@ -29,12 +24,12 @@
 		},
 		{
 			"key": "auth_client_id",
-			"value": "YOURCLIENTID",
+			"value": "YOUR_CLIENT_ID",
 			"enabled": true
 		},
 		{
 			"key": "auth_client_secret",
-			"value": "YOURCLIENTSECRET",
+			"value": "YOUR_CLIENT_SECRET",
 			"enabled": true
 		},
 		{
@@ -44,7 +39,7 @@
 		},
 		{
 			"key": "subjectDid",
-			"value": "did:key:zUC753GLRxpugg8ZxgkFegUear5fxk8j8ajLUqUTGW4oJ1xyXjHuV4WtceFgp5Myu4fuKZ8PLYPLZHqE9DYmJnpdGeG1FqVY564UTaaaVXjBx8f9Wt7sGgiEq2wSmWCNW57p35D",
+			"value": "did:key:YOUR_SUBJECT_DID",
 			"enabled": true
 		},
 		{
@@ -53,9 +48,9 @@
 			"enabled": true
 		},
 		{
-			"key": " ",
-			"value": "",
-			"enabled": false
+			"key": "tenant_subdomain",
+			"value": "YOUR_MATTR_TENANT",
+			"enabled": true
 		}
 	],
 	"_postman_variable_scope": "environment",

--- a/postman/Platform Core API.postman_collection.json
+++ b/postman/Platform Core API.postman_collection.json
@@ -131,9 +131,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/.well-known/did-configuration",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/.well-known/did-configuration",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/"
 							],
 							"path": [
 								".well-known",
@@ -158,9 +158,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/.well-known/did-configuration",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/.well-known/did-configuration",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/"
 									],
 									"path": [
 										".well-known",
@@ -188,9 +188,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/dids/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -224,9 +224,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -267,9 +267,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -303,9 +303,9 @@
 						"method": "DELETE",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/dids/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -338,9 +338,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -381,9 +381,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -417,9 +417,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/dids",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -444,23 +444,13 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids?limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
 										"dids"
-									],
-									"query": [
-										{
-											"key": "limit",
-											"value": "2"
-										},
-										{
-											"key": "cursor",
-											"value": "Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h"
-										}
 									]
 								}
 							},
@@ -493,9 +483,9 @@
 							"raw": "{\n    \"method\": \"<string>\",\n    \"options\": \"<object>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/dids",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -524,9 +514,9 @@
 									"raw": "{\n    \"method\": \"key\",\n    \"options\": {\n        \"keyType\": \"ed25519\"\n    }\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -565,9 +555,9 @@
 									"raw": "{\n    \"method\": \"key\",\n    \"options\": {\n        \"keyType\": \"ed25519\"\n    }\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/dids",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/dids",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -619,9 +609,9 @@
 							"raw": "{\n    \"didUrl\": \"<string>\",\n    \"payload\": \"<object>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/messaging/sign",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/sign",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -651,9 +641,9 @@
 									"raw": "{\n    \"didUrl\": \"did:example:abcdefghijkl#key1\",\n    \"payload\": {\n        \"msg\": \"this is a message\"\n    }\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/sign",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/sign",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -693,9 +683,9 @@
 									"raw": "{\n    \"didUrl\": \"did:example:abcdefghijkl#key1\",\n    \"payload\": {\n        \"msg\": \"this is a message\"\n    }\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/sign",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/sign",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -733,9 +723,9 @@
 							"raw": "{\n    \"jws\": \"<string>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/messaging/verify",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -765,9 +755,9 @@
 									"raw": "{\n    \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -807,9 +797,9 @@
 									"raw": "{\n    \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -847,9 +837,9 @@
 							"raw": "{\n    \"jws\": \"<string>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/messaging/verify",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -879,9 +869,9 @@
 									"raw": "{\n    \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -921,9 +911,9 @@
 									"raw": "{\n    \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -961,9 +951,9 @@
 							"raw": "{\n    \"jws\": \"<string>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/messaging/verify",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -993,9 +983,9 @@
 									"raw": "{\n    \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1035,9 +1025,9 @@
 									"raw": "{\n    \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/messaging/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/messaging/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1080,9 +1070,9 @@
 							"raw": "{\n    \"@context\": [\n        \"<string>\",\n        \"<string>\"\n    ],\n    \"type\": [\n        \"<string>\",\n        \"<string>\"\n    ],\n    \"claims\": \"<object>\",\n    \"issuer\": {\n        \"id\": \"<string>\",\n        \"name\": \"<string>\"\n    },\n    \"subjectId\": \"<string>\",\n    \"tag\": \"<string>\",\n    \"persist\": \"<boolean>\",\n    \"revocable\": \"<boolean>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1111,9 +1101,9 @@
 									"raw": "{\n    \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://schema.org\"\n    ],\n    \"subjectId\": \"did:key:z6Mkvji7zrwyFATXUzGNBSCnrPaZy7H3BWUnihrHvZdkEd9y\",\n    \"type\": [\n        \"VerifiableCredential\",\n        \"AlumniCredential\"\n    ],\n    \"claims\": {\n        \"givenName\": \"Jamie\",\n        \"familyName\": \"Doe\",\n        \"alumniOf\": \"Example University\"\n    },\n    \"issuer\": {\n        \"id\": \"did:key:z6MkjBWPPa1njEKygyr3LR3pRKkqv714vyTkfnUdP6ToFSH5\",\n        \"name\": \"Example University\"\n    },\n    \"persist\": true,\n    \"tag\": \"identifier123\",\n    \"revocable\": true\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1152,9 +1142,9 @@
 									"raw": "{\n    \"@context\": [\n        \"https://www.w3.org/2018/credentials/v1\",\n        \"https://schema.org\"\n    ],\n    \"subjectId\": \"did:key:z6Mkvji7zrwyFATXUzGNBSCnrPaZy7H3BWUnihrHvZdkEd9y\",\n    \"type\": [\n        \"VerifiableCredential\",\n        \"AlumniCredential\"\n    ],\n    \"claims\": {\n        \"givenName\": \"Jamie\",\n        \"familyName\": \"Doe\",\n        \"alumniOf\": \"Example University\"\n    },\n    \"issuer\": {\n        \"id\": \"did:key:z6MkjBWPPa1njEKygyr3LR3pRKkqv714vyTkfnUdP6ToFSH5\",\n        \"name\": \"Example University\"\n    },\n    \"persist\": true,\n    \"tag\": \"identifier123\",\n    \"revocable\": true\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1182,9 +1172,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials?tag=<string>&type=<string>&limit=<number>&cursor=<string>",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials?tag=<string>&type=<string>&limit=<number>&cursor=<string>",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1231,9 +1221,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials?tag=identifier123&type=AlumniCredential&limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials?tag=identifier123&type=AlumniCredential&limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1286,9 +1276,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials?tag=identifier123&type=AlumniCredential&limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials?tag=identifier123&type=AlumniCredential&limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1334,9 +1324,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1370,9 +1360,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1413,9 +1403,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1456,9 +1446,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1492,9 +1482,9 @@
 						"method": "DELETE",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1528,9 +1518,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1571,9 +1561,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1614,9 +1604,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1659,9 +1649,9 @@
 							"raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"sunt est ea\",\n            \"cillum ullamco id\"\n        ],\n        \"type\": [\n            \"minim laboris dolor\",\n            \"laboris\"\n        ],\n        \"issuanceDate\": \"1963-07-12T10:54:56.293Z\",\n        \"credentialSubject\": {\n            \"id\": \"dolor et pariatur sint minim\",\n            \"givenName\": \"ea tempor elit\",\n            \"familyName\": \"minim aliqua consequat\",\n            \"alumniOf\": \"Duis aliqua nostrud Ut\"\n        },\n        \"proof\": {\n            \"type\": \"dolor occaecat aliquip\",\n            \"created\": \"1997-08-30T18:26:39.564Z\",\n            \"jws\": \"Lorem Duis veniam proident\",\n            \"proofPurpose\": \"Ut amet fugiat pariatur\",\n            \"verificationMethod\": \"cillum sit\"\n        },\n        \"issuer\": {\n            \"id\": \"pariatur magna enim consequat\",\n            \"name\": \"est cillum irure officia aute\"\n        },\n        \"credentialStatus\": {\n            \"id\": \"labore fugiat\",\n            \"type\": \"laborum et magna non\",\n            \"revocationListIndex\": 62180854,\n            \"revocationListCredential\": \"sit amet consequat Excepteur\"\n        }\n    }\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials/verify",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/verify",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1691,9 +1681,9 @@
 									"raw": "{\n    \"credential\": {\n        \"@context\": [\n            \"https://www.w3.org/2018/credentials/v1\",\n            \"https://www.w3.org/2018/credentials/examples/v1\"\n        ],\n        \"type\": [\n            \"VerifiableCredential\",\n            \"AlumniCredential\"\n        ],\n        \"issuanceDate\": \"2020-05-02T12:06:29.156Z\",\n        \"credentialSubject\": {\n            \"givenName\": \"Jamie\",\n            \"familyName\": \"Doe\"\n        },\n        \"proof\": {\n            \"type\": \"Ed25519Signature2018\",\n            \"created\": \"2020-05-02T12:06:29Z\",\n            \"jws\": \"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c\",\n            \"proofPurpose\": \"assertionMethod\",\n            \"verificationMethod\": \"did:issuer:abcdb1f712ebc6f1c276e12ec21\"\n        },\n        \"issuer\": {\n            \"id\": \"did:issuer:abcdb1f712ebc6f1c276e12ec21\",\n            \"name\": \"Example University\"\n        },\n        \"credentialStatus\": {\n            \"id\": \"https://tenant.vii.mattr.global/v1/revocation-lists/cc641396-3750-43c8-b8b8-f30d74eb3fb3#1\",\n            \"type\": \"RevocationList2020Status\",\n            \"revocationListIndex\": 1,\n            \"revocationListCredential\": \"https://tenant.vii.mattr.global/v1/revocation-lists/cc641396-3750-43c8-b8b8-f30d74eb3fb3\"\n        }\n    }\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/verify",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/verify",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1736,9 +1726,9 @@
 							"raw": "{\n    \"isRevoked\": \"<boolean>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials/:id/revocation-status",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id/revocation-status",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1777,9 +1767,9 @@
 									"raw": "{\n    \"isRevoked\": true\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id/revocation-status",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id/revocation-status",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1825,9 +1815,9 @@
 									"raw": "{\n    \"isRevoked\": true\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id/revocation-status",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id/revocation-status",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1862,9 +1852,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/credentials/:id/revocation-status",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id/revocation-status",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -1899,9 +1889,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id/revocation-status",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id/revocation-status",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1943,9 +1933,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/credentials/:id/revocation-status",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/credentials/:id/revocation-status",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -1980,9 +1970,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/revocation-lists/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/revocation-lists/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -2016,9 +2006,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/revocation-lists/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/revocation-lists/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2059,9 +2049,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/revocation-lists/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/revocation-lists/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2109,9 +2099,9 @@
 							"raw": "{\n    \"domain\": \"<string>\",\n    \"name\": \"<string>\",\n    \"query\": [\n        {\n            \"type\": \"<string>\",\n            \"credentialQuery\": [\n                {\n                    \"required\": \"<boolean>\",\n                    \"example\": [\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        },\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        }\n                    ],\n                    \"reason\": \"<string>\"\n                },\n                {\n                    \"required\": \"<boolean>\",\n                    \"example\": [\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        },\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        }\n                    ],\n                    \"reason\": \"<string>\"\n                }\n            ]\n        },\n        {\n            \"type\": \"<string>\",\n            \"credentialQuery\": [\n                {\n                    \"required\": \"<boolean>\",\n                    \"example\": [\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        },\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        }\n                    ],\n                    \"reason\": \"<string>\"\n                },\n                {\n                    \"required\": \"<boolean>\",\n                    \"example\": [\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        },\n                        {\n                            \"@context\": \"<array>\",\n                            \"type\": \"<string>\",\n                            \"trustedIssuer\": [\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                },\n                                {\n                                    \"value\": \"<Error: Too many levels of nesting to fake this schema>\"\n                                }\n                            ]\n                        }\n                    ],\n                    \"reason\": \"<string>\"\n                }\n            ]\n        }\n    ]\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/presentations/templates",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -2141,9 +2131,9 @@
 									"raw": "{\n    \"domain\": \"tenant.vii.mattr.global\",\n    \"name\": \"alumni_credential_request\",\n    \"query\": [\n        {\n            \"type\": \"QueryByExample\",\n            \"credentialQuery\": [\n                {\n                    \"required\": true,\n                    \"reason\": \"We need you to prove your alumni membership.\",\n                    \"example\": {\n                        \"@context\": [\n                            \"https://schema.org\"\n                        ],\n                        \"type\": \"AlumniCredential\",\n                        \"trustedIssuer\": [\n                            {\n                                \"required\": true,\n                                \"issuer\": \"did:key:z6MkjBWPPa1njEKygyr3LR3pRKkqv714vyTkfnUdP6ToFSH5\"\n                            }\n                        ]\n                    }\n                }\n            ]\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2183,9 +2173,9 @@
 									"raw": "{\n    \"domain\": \"tenant.vii.mattr.global\",\n    \"name\": \"alumni_credential_request\",\n    \"query\": [\n        {\n            \"type\": \"QueryByExample\",\n            \"credentialQuery\": [\n                {\n                    \"required\": true,\n                    \"reason\": \"We need you to prove your alumni membership.\",\n                    \"example\": {\n                        \"@context\": [\n                            \"https://schema.org\"\n                        ],\n                        \"type\": \"AlumniCredential\",\n                        \"trustedIssuer\": [\n                            {\n                                \"required\": true,\n                                \"issuer\": \"did:key:z6MkjBWPPa1njEKygyr3LR3pRKkqv714vyTkfnUdP6ToFSH5\"\n                            }\n                        ]\n                    }\n                }\n            ]\n        }\n    ]\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2214,9 +2204,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/presentations/templates?limit=<number>&cursor=<string>",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates?limit=<number>&cursor=<string>",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -2254,9 +2244,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates?limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates?limit=2&cursor=Y3JlYXRlZEF0PTIwMjAtMDgtMjVUMDY6NDY6MDkuNTEwWiZpZD1h",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2295,9 +2285,9 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -2332,9 +2322,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2376,9 +2366,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2420,9 +2410,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2457,9 +2447,9 @@
 						"method": "DELETE",
 						"header": [],
 						"url": {
-							"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -2494,9 +2484,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2538,9 +2528,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2582,9 +2572,9 @@
 									}
 								],
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/templates/:id",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/templates/:id",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2628,9 +2618,9 @@
 							"raw": "{\n    \"templateId\": \"<string>\",\n    \"did\": \"<string>\",\n    \"challenge\": \"<string>\",\n    \"expiresTime\": \"<number>\",\n    \"callbackUrl\": \"<uri>\"\n}"
 						},
 						"url": {
-							"raw": "{{baseUrl}}/v1/presentations/requests",
+							"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/requests",
 							"host": [
-								"{{baseUrl}}"
+								"{{tenant_subdomain}}.vii.mattr.global/core"
 							],
 							"path": [
 								"v1",
@@ -2660,9 +2650,9 @@
 									"raw": "{\n    \"templateId\": \"64e45290-9980-11ea-b872-f1bee5fb328f\",\n    \"did\": \"did:key:z6Mkt7bFYc4V2HdAxwhMtaY6cgJckYXwhYdPLJCcnVqzrkpr\",\n    \"challenge\": \"64e45290-9980-11ea-b872-f1bee5fb328f\",\n    \"expiresTime\": 1592955632103,\n    \"callbackUrl\": \"https://tenant.vii.mattr.global/v1/presentations/response\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/requests",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/requests",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",
@@ -2702,9 +2692,9 @@
 									"raw": "{\n    \"templateId\": \"64e45290-9980-11ea-b872-f1bee5fb328f\",\n    \"did\": \"did:key:z6Mkt7bFYc4V2HdAxwhMtaY6cgJckYXwhYdPLJCcnVqzrkpr\",\n    \"challenge\": \"64e45290-9980-11ea-b872-f1bee5fb328f\",\n    \"expiresTime\": 1592955632103,\n    \"callbackUrl\": \"https://tenant.vii.mattr.global/v1/presentations/response\"\n}"
 								},
 								"url": {
-									"raw": "{{baseUrl}}/v1/presentations/requests",
+									"raw": "{{tenant_subdomain}}.vii.mattr.global/core/v1/presentations/requests",
 									"host": [
-										"{{baseUrl}}"
+										"{{tenant_subdomain}}.vii.mattr.global/core"
 									],
 									"path": [
 										"v1",


### PR DESCRIPTION
Building on top of PR #91 but all commits are signed

**⚠️ Problem encountered:**
Some API endpoints from `Platform core` uses slightly different root URL than others, but the current postman file doesn't take them into consideration, this PR addresses these issues.

**📝 Solution:**
Instead of using `baseUrl` with `https://tenant.vii.mattr.global/core` as a value across all endpoints, we simply let postman users pass in a `tenant_subdomain` in the Postman environment (which is a part of URLs such as `https://tenant.vii.mattr.global/`), and then construct individual API requests using `tenant_subdomain` alone, so that users don't have to modify individual endpoints by themselves.

**🧪 How to test out the changes**
1. Copy and import BOTH the `postman-collection` and `postman-environment` files into your postman environment
2. Follow existing instructions to test out postman collections 