### PR TITLE
fix: remove link to insomnia

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A collection of developer apps and API tooling that you can use to interface wit
 * [credential-templates](/credential-templates/README.md) – Credential template files for use with MATTR VII. Example files available for profiles: Compact, Compact Semantic.
 
 ## API Guides
-* Insomnia Core [import format](insomnia/README.md)
 * Postman Collection & Env [import files](/postman/README.md)
 
 ## Related Projects


### PR DESCRIPTION
Found out that readme file in root folder contains a link pointing to the insomnia folder (which was deleted), so here's a fix for deleting the reference