### PR TITLE
fix: use jwt setters without manually adding iss & aud to payload

### DIFF
--- a/credential-provider/src/services/core.service.ts
+++ b/credential-provider/src/services/core.service.ts
@@ -119,18 +119,15 @@ export class CoreService {
     const issuer = decoded.aud as string; // Sample app is the issuer of responseToken
     const audience = decoded.iss; // Platform is the audience of the responseToken
 
-    const responseTokenPayload = {
+    const payload = {
       // IMPORTANT: The state must be signed to prevent CSRF attacks.
       state: verifiedJwt.payload.state,
 
-      // The claims to be merged is optional.
-      claims: {
-        issuer,
-        audience,
-      },
+      // You can map any additional info into claims if you wish
+      claims: {},
     };
 
-    const responseToken = await new SignJWT(responseTokenPayload)
+    const responseToken = await new SignJWT(payload)
       .setProtectedHeader({ alg: 'HS256', typ: 'JWT' })
       .setIssuedAt()
       .setExpirationTime('1m')

--- a/credential-provider/src/services/core.service.ts
+++ b/credential-provider/src/services/core.service.ts
@@ -5,6 +5,7 @@ import { CreateCredentialConfigReqBody } from '@/types/create-credential-config.
 import {
   CreateCallbackUrlArgs,
   CreateInteractionHookResponseTokenArgs,
+  ResponseTokenPayload,
   VerifyInteractionHookTokenArgs,
 } from '@/types/create-callback-url';
 import { AuthProvider } from '@/types/get-auth-providers.res.body';
@@ -119,7 +120,7 @@ export class CoreService {
     const issuer = decoded.aud as string; // Sample app is the issuer of responseToken
     const audience = decoded.iss; // Platform is the audience of the responseToken
 
-    const payload = {
+    const payload: ResponseTokenPayload<unknown, unknown> = {
       // IMPORTANT: The state must be signed to prevent CSRF attacks.
       state: verifiedJwt.payload.state,
 

--- a/credential-provider/src/types/create-callback-url.ts
+++ b/credential-provider/src/types/create-callback-url.ts
@@ -14,3 +14,8 @@ export type CreateInteractionHookResponseTokenArgs = {
   verifiedJwt: JWTVerifyResult;
   secret: Buffer;
 };
+
+export type ResponseTokenPayload<State = any, Claims = any> = {
+  state: State;
+  claims: Claims;
+};


### PR DESCRIPTION
# Context:
We're introducing new capabilities to MATTR VII so that it verifies `iss` and `aud` on newly created response tokens for interaction-hook sessions, this PR helps showcasing ways to create response tokens (hence callbackUrls) in-compliance to this change