### PR TITLE
chore: update verifier sdk version

### DIFF
--- a/mobile-credential-online-presentation/README.md
+++ b/mobile-credential-online-presentation/README.md
@@ -1,6 +1,3 @@
-> [!NOTE]
-> This is a tech preview. If you are interested in trialling this capability, please reach out via [https://mattr.global/contact-us](https://mattr.global/contact-us).
-
 # Mobile Credential Online Presentation Sample App
 
 This sample app demonstrates using the Verifier Web SDK for online presentation of [Mobile Credentials](https://learn.mattr.global/docs/profiles/mobile) via either a same-device or cross-device workflow.

--- a/mobile-credential-online-presentation/package.json
+++ b/mobile-credential-online-presentation/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mattrglobal/verifier-sdk-web": "0.1.1-preview.1348",
+    "@mattrglobal/verifier-sdk-web": "1.0.1",
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18"


### PR DESCRIPTION
# Description

Use version `1.0.1` version of the Verifier SDK Web and remove the tech preview note from the README.