### PR TITLE
fix: undefined wallet provider ID

### DIFF
--- a/verifier-web-tutorial/src/app/page.tsx
+++ b/verifier-web-tutorial/src/app/page.tsx
@@ -43,12 +43,13 @@ export default function Home() {
     } as MATTRVerifierSDK.CredentialQuery
 
     // Step 4.2 - Add credential request
+    const walletProviderId = process.env.NEXT_PUBLIC_WALLET_PROVIDER_ID
     const options: MATTRVerifierSDK.RequestCredentialsOptions = {
       credentialQuery: [credentialQuery],
       // Step 6.2 - Use challenge from backend
       challenge: await createRequest(),
       openid4vpConfiguration: {
-        walletProviderId: process.env.NEXT_PUBLIC_WALLET_PROVIDER_ID,
+        ...(walletProviderId && { walletProviderId }),
         redirectUri: window.location.origin
       }
     }


### PR DESCRIPTION
# Description

If no wallet provider ID is configured in the environment variables, don't include the `walletProviderId` field in the credential request.