### PR TITLE
feat: Keep Android sample `repo` folder present after clone

### DIFF
--- a/android-holder-tutorial-sample-app/repo/README.md
+++ b/android-holder-tutorial-sample-app/repo/README.md
@@ -1,0 +1,15 @@
+# Local SDK repository
+
+This folder is the local Maven repository for the MATTR mDocs Holder SDK. It is
+referenced from `settings.gradle.kts` as `maven { url = uri("repo") }`.
+
+To set up the SDK:
+
+1. Unzip the `mobile-credential-holder-<version>.zip` package supplied by MATTR.
+2. Drag the unzipped `global` folder into this `repo` folder, so the layout is
+   `repo/global/...`.
+3. Sync the project with Gradle files to pick up the new module.
+
+> The SDK contents (`repo/global/`) are intentionally excluded from version
+> control via `.gitignore`. This README keeps the otherwise-empty `repo` folder
+> present after cloning or downloading the project.

--- a/android-in-person-verifier-tutorial-sample-app/repo/README.md
+++ b/android-in-person-verifier-tutorial-sample-app/repo/README.md
@@ -1,0 +1,15 @@
+# Local SDK repository
+
+This folder is the local Maven repository for the MATTR mDocs Verifier SDK. It is
+referenced from `settings.gradle.kts` as `maven { url = uri("repo") }`.
+
+To set up the SDK:
+
+1. Unzip the `mobile-credential-verifier-<version>.zip` package supplied by MATTR.
+2. Drag the unzipped `global` folder into this `repo` folder, so the layout is
+   `repo/global/...`.
+3. Sync the project with Gradle files to pick up the new module.
+
+> The SDK contents (`repo/global/`) are intentionally excluded from version
+> control via `.gitignore`. This README keeps the otherwise-empty `repo` folder
+> present after cloning or downloading the project.

--- a/android-remote-verification-tutorial-sample-app/repo/README.md
+++ b/android-remote-verification-tutorial-sample-app/repo/README.md
@@ -1,0 +1,15 @@
+# Local SDK repository
+
+This folder is the local Maven repository for the MATTR mDocs Verifier SDK. It is
+referenced from `settings.gradle.kts` as `maven { url = uri("repo") }`.
+
+To set up the SDK:
+
+1. Unzip the `mobile-credential-verifier-<version>.zip` package supplied by MATTR.
+2. Drag the unzipped `global` folder into this `repo` folder, so the layout is
+   `repo/global/...`.
+3. Sync the project with Gradle files to pick up the new module.
+
+> The SDK contents (`repo/global/`) are intentionally excluded from version
+> control via `.gitignore`. This README keeps the otherwise-empty `repo` folder
+> present after cloning or downloading the project.


### PR DESCRIPTION
## Problem

A customer following the [Android SDK quickstart](https://learn.mattr.global/docs/holding/sdk-quickstart#android-configure) reported that the downloaded sample app has no `repo` folder, so they couldn't complete the step:

> Drag the unzipped `global` folder into the project's `repo` folder.

### Root cause

All three Android tutorial sample apps reference a local Maven `repo` folder from `settings.gradle.kts`:

```kotlin
maven { url = uri("repo") }
```

The folder was empty, and **git does not track empty directories** — so it is absent on a fresh clone or `download-directory.github.io` download. The quickstart step then has no target folder. (`*/repo/global/` is gitignored, which is correct — the SDK contents should not be committed.)

## Fix

Add a `repo/README.md` to each of the three Android samples:

- `android-holder-tutorial-sample-app`
- `android-in-person-verifier-tutorial-sample-app`
- `android-remote-verification-tutorial-sample-app`

The README keeps the otherwise-empty folder present after clone/download, and documents what goes there (`repo/global/`), referencing the correct SDK artifact per sample (holder vs verifier). SDK contents stay gitignored.

## Testing

- Confirmed `repo/` is now tracked by git in all three samples.
- Confirmed `repo/.gitkeep`/`README.md` is not caught by `.gitignore` (only `*/repo/global/` is ignored).
- Verified artifact wording against each `app/build.gradle.kts` (`global.mattr.mobilecredential:holder` vs `:verifier`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)