### PR TITLE
fix(verifier): support SDK Tethering in iOS & Android verifier sample apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ README.private.md
 .env
 .env.local
 .env.development.local
+# Superpowers process artifacts (specs/plans) - do not commit to product PRs
+docs/superpowers/

--- a/android-in-person-verifier-tutorial-sample-app/app/src/main/java/com/example/verifiertutorial/Constants.kt
+++ b/android-in-person-verifier-tutorial-sample-app/app/src/main/java/com/example/verifiertutorial/Constants.kt
@@ -1,0 +1,13 @@
+package com.example.verifiertutorial
+
+// Constants
+// These values are specific to your own MATTR VII tenant and to the Verifier
+// Application configuration you create within it.
+// Replace both placeholders before running a real verification:
+//   - TENANT_HOST: the base URL of your MATTR VII tenant.
+//   - APPLICATION_ID: the `id` returned when you create the Verifier Application
+//     configuration on your tenant.
+object Constants {
+    const val TENANT_HOST = "https://your-tenant.vii.mattr.global"
+    const val APPLICATION_ID = "<YOUR_VERIFIER_APPLICATION_ID>"
+}

--- a/android-in-person-verifier-tutorial-sample-app/app/src/main/java/com/example/verifiertutorial/MainActivity.kt
+++ b/android-in-person-verifier-tutorial-sample-app/app/src/main/java/com/example/verifiertutorial/MainActivity.kt
@@ -21,7 +21,7 @@ import androidx.navigation.compose.rememberNavController
 import com.example.verifiertutorial.ui.theme.VerifierTutorialTheme
 import global.mattr.mobilecredential.verifier.dto.MobileCredentialResponse
 import global.mattr.mobilecredential.verifier.MobileCredentialVerifier
-import global.mattr.mobilecredential.common.platformconfig.PlatformConfiguration
+import global.mattr.mobilecredential.verifier.platformconfig.PlatformConfiguration
 import global.mattr.mobilecredential.verifier.exception.VerifierException.FailedToRegisterException
 import global.mattr.mobilecredential.verifier.exception.VerifierException.InvalidLicenseException
 import kotlinx.coroutines.launch

--- a/android-in-person-verifier-tutorial-sample-app/app/src/main/java/com/example/verifiertutorial/MainActivity.kt
+++ b/android-in-person-verifier-tutorial-sample-app/app/src/main/java/com/example/verifiertutorial/MainActivity.kt
@@ -38,8 +38,8 @@ class MainActivity : ComponentActivity() {
             // registers this app instance with the tenant and obtains a license, so a PlatformConfiguration
             // pointing at your tenant and Verifier Application is required.
             val platformConfiguration = PlatformConfiguration(
-                tenantHost = URL("https://your-tenant.vii.mattr.global"),
-                applicationId = "<YOUR_VERIFIER_APPLICATION_ID>"
+                tenantHost = URL(Constants.TENANT_HOST),
+                applicationId = Constants.APPLICATION_ID
             )
             try {
                 // This function initializes storage, registers the app instance, obtains a license,

--- a/android-remote-verification-tutorial-sample-app/app/src/main/java/com/example/mobileverifiertutorial/MainActivity.kt
+++ b/android-remote-verification-tutorial-sample-app/app/src/main/java/com/example/mobileverifiertutorial/MainActivity.kt
@@ -29,7 +29,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.mobileverifiertutorial.ui.theme.MobileVerifierTutorialTheme
 import global.mattr.mobilecredential.verifier.MobileCredentialVerifier
 import global.mattr.mobilecredential.verifier.OnlinePresentationSessionResult
-import global.mattr.mobilecredential.common.platformconfig.PlatformConfiguration
+import global.mattr.mobilecredential.verifier.platformconfig.PlatformConfiguration
 import global.mattr.mobilecredential.verifier.deviceretrieval.devicerequest.DataElements
 import global.mattr.mobilecredential.verifier.deviceretrieval.devicerequest.NameSpaces
 import global.mattr.mobilecredential.verifier.dto.MobileCredentialPresentation

--- a/ios-in-person-verifier-tutorial-sample-app/In person verification tutorial.xcodeproj/project.pbxproj
+++ b/ios-in-person-verifier-tutorial-sample-app/In person verification tutorial.xcodeproj/project.pbxproj
@@ -265,6 +265,8 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to the holder's wallet and receive the mDoc during in-person verification.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to scan the QR code that initiates an in-person verification session.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -297,6 +299,8 @@
 				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription = "This app uses Bluetooth to connect to the holder's wallet and receive the mDoc during in-person verification.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "This app uses the camera to scan the QR code that initiates an in-person verification session.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/ios-in-person-verifier-tutorial-sample-app/In person verification tutorial/DocumentView.swift
+++ b/ios-in-person-verifier-tutorial-sample-app/In person verification tutorial/DocumentView.swift
@@ -117,7 +117,9 @@ class DocumentViewModel {
         self.docType = presentation.docType
         self.verificationResult = presentation.verificationResult.verified ? "Verified" : "Invalid"
         // From v6.0.0, the failure detail is exposed via `failureType` (was `reason`).
-        self.verificationFailedReason = presentation.verificationResult.failureType?.message
+        // `MobileCredentialVerificationFailureType` is a String-backed enum; its `rawValue`
+        // is the human-readable failure message (e.g. "mDoc authentication failed").
+        self.verificationFailedReason = presentation.verificationResult.failureType?.rawValue
         
         self.namespacesAndClaims = presentation.claims?.reduce(into: [String: [String: String]]()) { result, outerElement in
             let (outerKey, innerDict) = outerElement

--- a/ios-remote-verification-tutorial-sample-app/Remote verification tutorial/DocumentView.swift
+++ b/ios-remote-verification-tutorial-sample-app/Remote verification tutorial/DocumentView.swift
@@ -112,7 +112,9 @@ class DocumentViewModel: ObservableObject {
         self.docType = presentation.docType
         self.verificationResult = presentation.verificationResult.verified ? "Verified" : "Invalid"
         // From v6.0.0, the failure detail is exposed via `failureType` (was `reason`).
-        self.verificationFailedReason = presentation.verificationResult.failureType?.message
+        // `MobileCredentialVerificationFailureType` is a String-backed enum; its `rawValue`
+        // is the human-readable failure message (e.g. "mDoc authentication failed").
+        self.verificationFailedReason = presentation.verificationResult.failureType?.rawValue
 
         self.namespacesAndClaims = presentation.claims?.reduce(into: [String: [String: String]]()) { result, outerElement in
             let (outerKey, innerDict) = outerElement


### PR DESCRIPTION
Fixes a set of issues that prevent the iOS and Android verifier tutorial sample apps from building and running against the tethered Verifier SDK (Android Verifier SDK v7.0.0+ / the matching iOS release), where the SDK is tethered to a MATTR VII tenant and requires a `PlatformConfiguration` at initialization.

## 1. Android: wrong `PlatformConfiguration` import (build error)

Both Android verifier samples imported `PlatformConfiguration` from the `common` package:

```kotlin
import global.mattr.mobilecredential.common.platformconfig.PlatformConfiguration   // ❌ does not resolve
```

The published **Verifier** SDK artifact repackages the common sources — `Verifier/transform-sources.gradle` rewrites `global.mattr.mobilecredential.common` to `global.mattr.mobilecredential.verifier` — so the class ships under the `verifier` namespace. Corrected to:

```kotlin
import global.mattr.mobilecredential.verifier.platformconfig.PlatformConfiguration  // ✅
```

Applied to both:
- `android-in-person-verifier-tutorial-sample-app`
- `android-remote-verification-tutorial-sample-app`

## 2. iOS build error: `failureType?.message` does not compile

```
Value of type 'MobileCredentialVerificationFailureType' has no member 'message'
```

`MobileCredentialVerificationFailureType` is a `String`-backed enum with **no `message` property** — `message` only exists as an internal `CodingKey`. Switched to the enum's `rawValue`, which is the human-readable failure message (e.g. `"mDoc authentication failed"`).

Applied to both sample apps:
- `ios-in-person-verifier-tutorial-sample-app`
- `ios-remote-verification-tutorial-sample-app`

## 3. iOS crash on "Scan QR Code": missing camera usage description

```
This app has crashed because it attempted to access privacy-sensitive data
without a usage description. The app's Info.plist must contain an
NSCameraUsageDescription key...
```

The in-person sample uses `GENERATE_INFOPLIST_FILE = YES` and declared no camera usage description. Added to both the Debug and Release configs:
- `INFOPLIST_KEY_NSCameraUsageDescription` — for QR scanning.
- `INFOPLIST_KEY_NSBluetoothAlwaysUsageDescription` — for the subsequent BLE proximity session, which would otherwise crash on the next step.

The remote verification sample uses neither camera nor Bluetooth, so it needs no usage descriptions.

## 4. Android in-person sample: extract tenant config into a `Constants` file

Tethering requires a tenant-specific `PlatformConfiguration`. `MainActivity.kt` hard-coded the `tenantHost` and `applicationId` placeholders inline. Moved them into a new `Constants.kt` (`TENANT_HOST` / `APPLICATION_ID`) with guidance comments, and updated `MainActivity` to read from it — giving a single, documented place to drop in tenant-specific values.

## 5. Repo hygiene

Added `docs/superpowers/` to `.gitignore` so Superpowers process artifacts (specs/plans) don't get committed to product PRs.

## Out of scope (follow-ups)

The React Native verifier tutorials reference `verificationResult.reason.message`. That's a different (JS) SDK with a different result shape and was not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
