### PR TITLE
chore(react-native-mdocs-holder-tutorial): update for Holder SDK 10.0.0

### DIFF
--- a/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/app/claim-credential.tsx
+++ b/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/app/claim-credential.tsx
@@ -85,10 +85,31 @@ export default function ClaimCredential() {
 				retrieved.error.message || "Failed to retrieve credentials.",
 			);
 		} else {
-			Alert.alert(
-				"Success",
-				`Retrieved ${retrieved.value.length} credential(s) successfully!`,
-			);
+			// A credential offer can contain more than one credential, and each one is
+			// retrieved independently. Narrow each item on isSuccess so that a credential
+			// that failed to retrieve is not reported as a success.
+			let successCount = 0;
+			const failureMessages: string[] = [];
+
+			for (const item of retrieved.value) {
+				if (item.isSuccess) {
+					successCount++;
+				} else {
+					failureMessages.push(`${item.docType}: ${item.error.message}`);
+				}
+			}
+
+			if (failureMessages.length === 0) {
+				Alert.alert(
+					"Success",
+					`Retrieved ${successCount} credential(s) successfully!`,
+				);
+			} else {
+				Alert.alert(
+					"Partial Success",
+					`Retrieved ${successCount} credential(s). Failed to retrieve ${failureMessages.length}:\n${failureMessages.join("\n")}`,
+				);
+			}
 		}
 		// Refresh the list of mobile credentials in the holder application
 		await getMobileCredentials();
@@ -155,11 +176,12 @@ export default function ClaimCredential() {
 			<ScrollView style={{ flex: 1 }}>
 				{credentialOffer.credentials.map(
 					(cred: OfferedCredential, index: number) => (
-						<View key={`${cred.doctype}-${index}`} style={styles.card}>
+						<View key={`${cred.docType}-${index}`} style={styles.card}>
 							<Text style={styles.cardTitle}>{cred.name}</Text>
-							<Text style={styles.text}>Document Type: {cred.doctype}</Text>
+							<Text style={styles.text}>Document Type: {cred.docType}</Text>
+							{/* An offer only includes claims when it contains claim data */}
 							<Text style={styles.text}>
-								Number of Claims: {cred.claims?.length}
+								Number of Claims: {cred.claims?.length ?? 0}
 							</Text>
 						</View>
 					),

--- a/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/package.json
+++ b/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/package.json
@@ -13,7 +13,7 @@
 		"ios": "expo run:ios"
 	},
 	"dependencies": {
-		"@mattrglobal/mobile-credential-holder-react-native": "^8.1.1",
+		"@mattrglobal/mobile-credential-holder-react-native": "^10.0.0",
 		"expo": "^55",
 		"expo-build-properties": "~55.0.13",
 		"expo-constants": "~55.0.15",

--- a/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/providers/HolderProvider.tsx
+++ b/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/providers/HolderProvider.tsx
@@ -56,7 +56,7 @@ export function HolderProvider({ children }: { children: React.ReactNode }) {
 			const result = await initialize({
 				userAuthenticationConfiguration: {
 					userAuthenticationBehavior: UserAuthenticationBehavior.OnInitialize,
-					userAuthenticationType: UserAuthenticationType.BiometricOrPasscode,
+					userAuthenticationType: UserAuthenticationType.UserPresence,
 				},
 				credentialIssuanceConfiguration: {
 					autoTrustMobileCredentialIaca: true,
@@ -87,8 +87,23 @@ export function HolderProvider({ children }: { children: React.ReactNode }) {
 
 	const getMobileCredentials = useCallback(async () => {
 		if (!isHolderInitialized) return;
-		const credentials = await getCredentials();
-		setMobileCredentials(credentials);
+
+		try {
+			const result = await getCredentials();
+
+			if (result.isErr()) {
+				setError(result.error.message || "Failed to get credentials.");
+				return;
+			}
+
+			setMobileCredentials(result.value);
+		} catch (err) {
+			setError(
+				err instanceof Error
+					? err.message
+					: "Unknown error while getting credentials",
+			);
+		}
 	}, [isHolderInitialized]);
 
 	// When the holder is initialized, get the mobile credentials to display in the app
@@ -113,7 +128,18 @@ export function HolderProvider({ children }: { children: React.ReactNode }) {
 						style: "destructive",
 						onPress: async () => {
 							try {
-								await deleteCredential(credentialId);
+								const result = await deleteCredential(credentialId);
+
+								// Expected failures are returned as an error result rather
+								// than thrown, so handle them before reporting success
+								if (result.isErr()) {
+									Alert.alert(
+										"Error",
+										result.error.message || "Failed to delete credential.",
+									);
+									return;
+								}
+
 								Alert.alert("Success", "Credential deleted successfully.");
 								await getMobileCredentials();
 							} catch (err) {

--- a/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-starter/package.json
+++ b/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-starter/package.json
@@ -13,7 +13,7 @@
 		"ios": "expo run:ios"
 	},
 	"dependencies": {
-		"@mattrglobal/mobile-credential-holder-react-native": "^8.1.1",
+		"@mattrglobal/mobile-credential-holder-react-native": "^10.0.0",
 		"expo": "^55",
 		"expo-build-properties": "~55.0.13",
 		"expo-constants": "~55.0.15",


### PR DESCRIPTION
Updates the React Native mDocs Holder tutorial sample app for Holder SDK 10.0.0, shipping 2026-08-14.

Both projects were pinned to `^8.1.1` (resolving to 8.1.2). v8 reached End of Life on 2026-06-23, so this skips the v9 line and moves straight to `^10.0.0`.

The MATTR Learn quickstart and credential-claiming tutorial send readers to these projects and instruct them to run `yarn install`, so the pin here is what a reader actually gets.

## Changes

`react-native-mdocs-holder-tutorial-starter` needed only the version bump. Its SDK surface is a single type-only import, and the tutorial code is what the reader writes.

`react-native-mdocs-holder-tutorial-complete`:

- **`OfferedCredential.doctype` is now `docType`** (`app/claim-credential.tsx`). Two sites: the React key and the rendered "Document Type" text. Both would have become `undefined`.
- **`getCredentials` and `deleteCredential` now return a `Result`** (`providers/HolderProvider.tsx`). `getCredentials` was being passed straight into a state setter typed as an array. The `deleteCredential` handler was wrapped in `try`/`catch` and always reported "Success": expected failures are now returned rather than thrown, so that catch was dead code for them and deletions could fail silently. Both were already wrong at v9.
- **Credential retrieval results are discriminated on `isSuccess`** (`app/claim-credential.tsx`). The code reported `retrieved.value.length` as the success count, so a credential that failed to retrieve was announced as retrieved. Now narrows each item and reports successes and failures separately.
- **`UserAuthenticationType.BiometricOrPasscode` is replaced by `UserPresence`**, which is also the new default.
- **`claims` on an offered credential is now optional**, so the claim count renders `0` rather than blank when absent.

## Deliberately not changed

- **No `platformConfiguration` / SDK Backend.** It is optional in 10.0.0, and enabling it would require a quickstart reader to own a MATTR VII tenant and two Holder Applications. The Learn quickstart links the SDK Backend guide as a next step instead.
- **The lockfiles.** They still pin 8.1.2 and cannot be regenerated correctly until 10.0.0 is published. See below.
- **`biome format` was not run.** These projects are tab-indented at roughly 80 columns while `biome.json` specifies 2-space at 120, so formatting them would rewrite whole files. Each edit matches its file's existing style. `biome lint` passes on both changed files.

## This diff is not typechecked

10.0.0 is not yet published to npm, so `yarn install` cannot resolve it and neither project has `node_modules`. Every change was made by reading the real 10.0.0 signatures in `js-credential-sdk` at `origin/am/rn-holder-10.0.0-changelog`, but nothing was compiled or run.

Once 10.0.0 is on npm, per project:

```
yarn install         # regenerates yarn.lock, which must be committed
npx tsc --noEmit     # the real gate on this PR
npx expo run:ios     # and run:android
```

Please treat `tsc --noEmit` passing as the merge condition, and do not merge before the release lands.

## One thing worth confirming

`withAndroidHolderSDK.js` references `global.mattr.mobilecredential.common.webcallback.WebCallbackActivity`. The v9 note about the package path moving from `...common` to `...holder` made this look like a break, but three sources agree the class FQN is unchanged: the native SDK source defines it under `common/`, the SDK's own `AndroidManifest.xml` declares the `.common` name, and the RN SDK's public README still documents it. Left as-is. Worth a one-line confirmation from the Android SDK team, because the internal Wallet app's manifests use a `.holder.webcallback` name that does not exist in the SDK source. If the class did move, Android credential claiming breaks here.

Related: mattrinternal/mattr-learn#1261 (the Learn changelog and docs for this release).
