### PR TITLE
fix(react-native-mdocs-holder-tutorial): set bleMode to MDocPeripheralServer

### DIFF
--- a/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/app/proximity-presentation.tsx
+++ b/react-native-mdocs-holder-tutorial/react-native-mdocs-holder-tutorial-complete/app/proximity-presentation.tsx
@@ -2,6 +2,7 @@
 import RequestCredentialSelector from "@/components/RequestCredentialSelector";
 import { useHolder } from "@/providers/HolderProvider";
 import {
+	BleMode,
 	type CreateProximityPresentationSessionOptions,
 	type PresentationSessionSuccessRequest,
 	createProximityPresentationSession,
@@ -64,6 +65,7 @@ export default function ProximityPresentation() {
 	const handleStartSession = useCallback(async () => {
 		try {
 			const options: CreateProximityPresentationSessionOptions = {
+				bleMode: BleMode.MDocPeripheralServer,
 				onRequestReceived: (data) => {
 					if ("error" in data) {
 						handleError(


### PR DESCRIPTION
## What

Sets `bleMode: BleMode.MDocPeripheralServer` on the proximity presentation session in the completed React Native mDocs holder tutorial app.

## Why

The [proximity presentation tutorial](https://learn.mattr.global/docs/holding/proximity-presentation-tutorial) documents this option and explains the reasoning: many modern POS terminals do not support BLE server mode, so starting the session with the holder as the BLE peripheral server maximizes compatibility when those terminals act as mDoc verifiers. The completed app was still relying on the SDK default, so a reader following the tutorial ended up with code that did not match the finished sample.

The Android and iOS tutorial apps already set the equivalent option.

## Testing

`npx tsc --noEmit` in `react-native-mdocs-holder-tutorial-complete` is clean, both before and after this change.

`bleMode` is typed as `BleMode | undefined`, where `BleMode` is a string enum, so the enum member is required. Verified against the installed SDK (`@mattrglobal/mobile-credential-holder-react-native` 10.0.0) with a small assignability probe: `BleMode.MDocPeripheralServer` typechecks, while the bare string `"MDocPeripheralServer"` fails with `TS2322: Type '"MDocPeripheralServer"' is not assignable to type 'BleMode | undefined'`.

A companion MATTR Learn PR corrects the tutorial snippet, which was publishing the bare string form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
